### PR TITLE
Handle missing static assets and external tools

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -70,4 +70,10 @@ async def process(
 # Locally
 # app.mount("/", StaticFiles(directory="../frontend/dist", html=True), name="frontend")
 # Docker
-app.mount("/", StaticFiles(directory="./static", html=True), name="frontend")
+static_dir = "./static"
+if os.path.isdir(static_dir):
+    app.mount("/", StaticFiles(directory=static_dir, html=True), name="frontend")
+else:
+    @app.get("/")
+    async def health_check():
+        return {"status": "ok"}

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 from tempfile import NamedTemporaryFile
+from PIL import Image
 
 def process_file(file, file_type, width, height, quality):
     print(f"Processing file: {file.filename}, type: {file_type}, width: {width}, height: {height}, quality: {quality}")
@@ -14,32 +15,54 @@ def process_file(file, file_type, width, height, quality):
     output_filename = os.path.basename(temp_input_path)
 
     if file_type == "PDF":
-        # Use Ghostscript for proper PDF compression
         output_path = os.path.join(output_dir, "processed_" + output_filename)
         quality_setting = f"/{quality}" if quality else "/ebook"
-        cmd = [
-            "gs",
-            "-sDEVICE=pdfwrite",
-            "-dCompatibilityLevel=1.4",
-            f"-dPDFSETTINGS={quality_setting}",
-            "-dNOPAUSE",
-            "-dQUIET",
-            "-dBATCH",
-            f"-sOutputFile={output_path}",
-            temp_input_path
-        ]
+        if shutil.which("gs"):
+            cmd = [
+                "gs",
+                "-sDEVICE=pdfwrite",
+                "-dCompatibilityLevel=1.4",
+                f"-dPDFSETTINGS={quality_setting}",
+                "-dNOPAUSE",
+                "-dQUIET",
+                "-dBATCH",
+                f"-sOutputFile={output_path}",
+                temp_input_path
+            ]
+            print(f"Running command: {' '.join(cmd)}")
+            try:
+                subprocess.run(cmd, check=True)
+            except subprocess.CalledProcessError as e:
+                print(f"Error during subprocess execution: {e}")
+                return None
+        else:
+            # Fallback: simply copy the file if Ghostscript is unavailable
+            shutil.copy(temp_input_path, output_path)
     else:
-        # For Images, use convert to create a new file
         output_path = os.path.join(output_dir, "processed_" + output_filename)
-        size_param = f"{width}x{height}" if width and height else "50%"
-        cmd = ["convert", temp_input_path, "-resize", size_param, output_path]
-
-    print(f"Running command: {' '.join(cmd)}")
-    try:
-        subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError as e:
-        print(f"Error during subprocess execution: {e}")
-        return None
+        if shutil.which("convert"):
+            size_param = f"{width}x{height}" if width and height else "50%"
+            cmd = ["convert", temp_input_path, "-resize", size_param, output_path]
+            print(f"Running command: {' '.join(cmd)}")
+            try:
+                subprocess.run(cmd, check=True)
+            except subprocess.CalledProcessError as e:
+                print(f"Error during subprocess execution: {e}")
+                return None
+        else:
+            # Fallback: use Pillow for image resizing if ImageMagick is unavailable
+            try:
+                with Image.open(temp_input_path) as img:
+                    if img.mode in ("RGBA", "P"):
+                        img = img.convert("RGB")
+                    if width and height:
+                        img = img.resize((width, height))
+                    else:
+                        img = img.resize((img.width // 2, img.height // 2))
+                    img.save(output_path)
+            except Exception as e:
+                print(f"Error during image processing: {e}")
+                return None
 
     if not os.path.exists(output_path):
         print(f"Expected output file does not exist: {output_path}")


### PR DESCRIPTION
## Summary
- Skip mounting frontend when the static directory is missing and provide a simple root health endpoint
- Fallback to Pillow or file copy when ImageMagick or Ghostscript are unavailable during file processing

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8bf0507d0832e9a8f91d26fe58754