### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection vulnerability in quality parameter

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,6 +86,12 @@ async def process(
     width = int(width) if width and width.isdigit() else None
     height = int(height) if height and height.isdigit() else None
 
+    if quality:
+        if file_type == "PDF" and quality not in {"screen", "ebook", "printer", "prepress", "default"}:
+            raise HTTPException(status_code=400, detail="Invalid quality setting for PDF")
+        if file_type == "Image" and not quality.isdigit():
+            raise HTTPException(status_code=400, detail="Invalid quality setting for Image")
+
     # Enforce size limit
     max_mb = int(os.getenv("MAX_UPLOAD_MB", "30"))
     max_bytes = max_mb * 1024 * 1024

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,7 +1,7 @@
-🛡️ Sentinel: [CRITICAL] Fix ImageMagick Extension Spoofing
+🛡️ Sentinel: [HIGH] Fix argument injection vulnerability in quality parameter
 
-🚨 Severity: CRITICAL
-💡 Vulnerability: The application trusted the user-provided file extension when creating temporary files for processing by ImageMagick. This allowed an attacker to bypass content-type validation and force ImageMagick to use a different decoder (like MSL or MVG) by spoofing the file extension, potentially leading to arbitrary code execution or SSRF.
-🎯 Impact: Remote Code Execution (RCE) or Server-Side Request Forgery (SSRF) via ImageMagick delegate injection.
-🔧 Fix: Mapped the validated `Content-Type` to a strictly controlled, known-safe file extension (`.jpg`, `.png`, `.webp`, `.pdf`) and used that for the temporary file instead of the user-provided filename's extension. Fallback to `.bin` for unknown types.
-✅ Verification: Ran `pytest` backend tests to ensure legitimate files are still processed correctly. Verified malicious payloads (e.g., SVG/MVG with `.jpg` extension) now fail safely because they are forced to be processed as JPEG or `.bin` files.
+🚨 Severity: HIGH
+💡 Vulnerability: The `quality` parameter was not validated before being passed to `subprocess.run` (Ghostscript and ImageMagick). An attacker could inject arbitrary arguments by providing crafted input like `"ebook\" -sOutputFile=/etc/passwd \""` which would then alter the behavior of the executed command.
+🎯 Impact: Arbitrary argument injection could lead to arbitrary file reads, writes, or execution depending on the tool's capabilities.
+🔧 Fix: Implemented strict allowlist validation for the `quality` parameter in `backend/app/main.py`. For PDFs, it must be one of the allowed Ghostscript settings (e.g., `screen`, `ebook`). For Images, it must be purely digits.
+✅ Verification: Ran `pytest` backend tests and Playwright frontend tests to ensure no regressions. Verified manually by sending crafted payloads which are now rejected with a 400 Bad Request.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `quality` parameter was not validated before being passed to `subprocess.run` (Ghostscript and ImageMagick). An attacker could inject arbitrary arguments by providing crafted input like `"ebook\" -sOutputFile=/etc/passwd \""` which would then alter the behavior of the executed command.
🎯 Impact: Arbitrary argument injection could lead to arbitrary file reads, writes, or execution depending on the tool's capabilities.
🔧 Fix: Implemented strict allowlist validation for the `quality` parameter in `backend/app/main.py`. For PDFs, it must be one of the allowed Ghostscript settings (e.g., `screen`, `ebook`). For Images, it must be purely digits.
✅ Verification: Ran `pytest` backend tests and Playwright frontend tests to ensure no regressions. Verified manually by sending crafted payloads which are now rejected with a 400 Bad Request.

---
*PR created automatically by Jules for task [3715486194779594215](https://jules.google.com/task/3715486194779594215) started by @omordach*