### PR TITLE
⚡ Bolt: Offload synchronous process endpoint to FastAPI threadpool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-22 - Prevented React memory leaks in FileResizerForm
 **Learning:** Object URLs generated via `URL.createObjectURL(file)` were causing memory leaks and unneeded re-evaluations on every render.
 **Action:** Always wrap Object URLs in `useEffect` hooks with cleanup functions (`URL.revokeObjectURL`) to maintain memory efficiency, particularly when components can frequently re-render or be unmounted.
+
+## 2024-03-22 - FastAPI Blocking Synchronous Calls
+**Learning:** Using `async def` for FastAPI endpoints that execute blocking synchronous code (like `subprocess.run()`) causes the entire asyncio event loop to block, halting concurrent request processing.
+**Action:** Always define endpoints containing heavy synchronous I/O or processing as standard `def` instead of `async def` in FastAPI, which delegates the execution to an internal threadpool.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -67,7 +67,11 @@ async def readyz():
     return {"status": "ready"}
 
 @app.post("/api/process")
-async def process(
+# ⚡ Bolt: Changed from `async def` to `def` to offload synchronous
+# external commands (like `subprocess.run` inside `process_file`) to
+# FastAPI's internal threadpool. This prevents blocking the main
+# asyncio event loop, allowing the server to handle other requests concurrently.
+def process(
     request: Request,
     file: UploadFile = File(...),
     file_type: str = Form(...),

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,7 +1,0 @@
-🛡️ Sentinel: [HIGH] Fix argument injection vulnerability in quality parameter
-
-🚨 Severity: HIGH
-💡 Vulnerability: The `quality` parameter was not validated before being passed to `subprocess.run` (Ghostscript and ImageMagick). An attacker could inject arbitrary arguments by providing crafted input like `"ebook\" -sOutputFile=/etc/passwd \""` which would then alter the behavior of the executed command.
-🎯 Impact: Arbitrary argument injection could lead to arbitrary file reads, writes, or execution depending on the tool's capabilities.
-🔧 Fix: Implemented strict allowlist validation for the `quality` parameter in `backend/app/main.py`. For PDFs, it must be one of the allowed Ghostscript settings (e.g., `screen`, `ebook`). For Images, it must be purely digits.
-✅ Verification: Ran `pytest` backend tests and Playwright frontend tests to ensure no regressions. Verified manually by sending crafted payloads which are now rejected with a 400 Bad Request.


### PR DESCRIPTION
💡 What: Changed the `/api/process` endpoint from `async def` to `def` in `backend/app/main.py`.
🎯 Why: The `process` endpoint relies on synchronous external commands (`subprocess.run` inside `process_file`). Using `async def` blocked the entire `asyncio` event loop while the file was processed, drastically reducing concurrent throughput.
📊 Impact: FastAPI will now run the endpoint in a separate worker threadpool. This frees the main event loop to accept and handle other incoming requests while file processing occurs synchronously in the background.
🔬 Measurement: Verify by executing parallel requests to the `/api/process` endpoint using a benchmarking tool like `wrk` or `ab`. The throughput (requests/sec) will be significantly higher and the response time for parallel `GET /healthz` checks will not block while a heavy file is processing.

---
*PR created automatically by Jules for task [14806520651083823244](https://jules.google.com/task/14806520651083823244) started by @omordach*