### PR TITLE
🛡️ Sentinel: Fix CI workflow failure by updating Trivy action tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           path: sbom.cdx.json
 
       - name: Trivy Scan
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@master
         with:
           image-ref: file-resizer-app:latest
           format: table


### PR DESCRIPTION
**Vulnerability:** CI workflow `build-test-secure` is failing because it cannot resolve `aquasecurity/trivy-action@0.24.0`. The exact tag without a `v` prefix was either deleted or never existed.

**Impact:** CI pipeline is broken, preventing testing and security scanning of new commits.

**Fix:** Changed the version reference of `aquasecurity/trivy-action` from `@0.24.0` to `@master` in `.github/workflows/ci.yml`. This ensures the action is always fetched successfully and unblocks the CI build.

**Verification:** Ran local checks, changes properly formatted and staged without any extraneous artifacts.

---
*PR created automatically by Jules for task [17824665833990117144](https://jules.google.com/task/17824665833990117144) started by @omordach*